### PR TITLE
fix: remove duplicate title

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,9 +1,7 @@
 ---
 layout: home
-hide_title: true
+title: Assessing and Enhancing Digital Accessibility of Biological Data and Visualizations
 ---
-
-# Assessing and Enhancing Digital Accessibility of Biological Data and Visualizations
 
 ## Background
 As computational biologists, we produce biological datasets, visualizations, and computational tools. Our shared goal is to make our data and tools widely usable and accessible. However, we often fail to meet the needs of certain groups of people. Our recent [comprehensive accessibility evaluation](https://inscidar.org) shows that biological data resources are largely inaccessible to people with disabilities, with severe accessibility issues in almost 75% of all 3,112 data portals included in the study. To address the critical accessibility barriers, it is important to increase awareness of accessibility in the community and teach the workforce practical ways to enhance the accessibility of biological data resources. While there are existing resources and training opportunities that focus on content that includes no or little data, there is a lack of solutions and resources that provide insights into how to make data-intensive content accessible.


### PR DESCRIPTION
Even though local dev shows the home page having the correct title, it seems like gh-pages changes something in the theme and the title is shown twice. Setting the title directly rather than with '#' fixes this.